### PR TITLE
Add better error handling for live environments

### DIFF
--- a/src/PopForums.Mvc/Areas/Forums/Controllers/ErrorController.cs
+++ b/src/PopForums.Mvc/Areas/Forums/Controllers/ErrorController.cs
@@ -1,0 +1,33 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+using Microsoft.AspNetCore.Mvc;
+
+namespace PopForums.Mvc.Areas.Forums.Controllers
+{
+	[Area("Forums")]
+	public class ErrorController : Controller
+	{
+		public static string Name = "Error";
+
+		public ActionResult Index(int code)
+		{
+			if (code == 401 || code == 403)
+			{
+				return View("/Areas/Forums/Views/Shared/Forbidden.cshtml");
+			}
+			else if (code == 404)
+			{
+				return View("/Areas/Forums/Views/Shared/NotFound.cshtml");
+			}
+
+			// Throw error below
+			return View("/Areas/Forums/Views/Shared/UnexpectedError.cshtml");
+		}
+
+		public ActionResult ThrowError()
+		{
+			throw new Exception("Manually generated 500 error");
+		}
+	}
+}

--- a/src/PopForums.Mvc/Areas/Forums/Extensions/RouteBuilders.cs
+++ b/src/PopForums.Mvc/Areas/Forums/Extensions/RouteBuilders.cs
@@ -75,6 +75,16 @@ namespace PopForums.Mvc.Areas.Forums.Extensions
 				"Forums/Admin/ErrorLog/{page?}",
 				new { controller = AdminController.Name, action = "ErrorLog", Area = "Forums" }
 				);
+			routes.MapRoute(
+				"pfthrowerror",
+				"Error/Throw",
+				new { controller = ErrorController.Name, action = "ThrowError", Area = "Forums" }
+				);
+			routes.MapRoute(
+				"pferror",
+				"Error/{code?}",
+				new { controller = ErrorController.Name, action = "Index", code = 500, Area = "Forums" }
+				);
 			return routes;
 		}
 	}

--- a/src/PopForums.Web/Areas/Forums/Views/Shared/UnexpectedError.cshtml
+++ b/src/PopForums.Web/Areas/Forums/Views/Shared/UnexpectedError.cshtml
@@ -1,0 +1,11 @@
+﻿@{
+	ViewBag.Title = PopForums.Resources.UnexpectedError;
+    Layout = "~/Areas/Forums/Views/Shared/PopForumsMaster.cshtml";
+}
+
+<div>
+	<h1>@PopForums.Resources.UnexpectedError</h1>
+	<ul id="TopBreadcrumb" class="breadcrumb">
+		<li><span class="glyphicon glyphicon-chevron-up"></span> @Html.ActionLink(PopForums.Resources.Forums, "Index", HomeController.Name, null, null)</li>
+	</ul>
+</div>

--- a/src/PopForums.Web/Properties/launchSettings.json
+++ b/src/PopForums.Web/Properties/launchSettings.json
@@ -1,27 +1,27 @@
 {
-	"iisSettings": {
-		"windowsAuthentication": false,
-		"anonymousAuthentication": true,
-		"iisExpress": {
-			"applicationUrl": "http://localhost:43200/",
-			"sslPort": 0
-		}
-	},
-	"profiles": {
-		"IIS Express": {
-			"commandName": "IISExpress",
-			"launchBrowser": true,
-			"environmentVariables": {
-				"ASPNETCORE_ENVIRONMENT": "Development"
-			}
-		},
-		"WebApplication1": {
-			"commandName": "Project",
-			"launchBrowser": true,
-			"launchUrl": "http://localhost:5000",
-			"environmentVariables": {
-				"ASPNETCORE_ENVIRONMENT": "Development"
-			}
-		}
-	}
+  "iisSettings": {
+    "windowsAuthentication": false,
+    "anonymousAuthentication": true,
+    "iisExpress": {
+      "applicationUrl": "http://localhost:43200/",
+      "sslPort": 0
+    }
+  },
+  "profiles": {
+    "IIS Express": {
+      "commandName": "IISExpress",
+      "launchBrowser": true,
+      "environmentVariables": {
+        "ASPNETCORE_ENVIRONMENT": "Production"
+      }
+    },
+    "WebApplication1": {
+      "commandName": "Project",
+      "launchBrowser": true,
+      "launchUrl": "http://localhost:5000",
+      "environmentVariables": {
+        "ASPNETCORE_ENVIRONMENT": "Development"
+      }
+    }
+  }
 }

--- a/src/PopForums/Resources/Resources.Designer.cs
+++ b/src/PopForums/Resources/Resources.Designer.cs
@@ -3014,6 +3014,15 @@ namespace PopForums {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Unexpected Error.
+        /// </summary>
+        public static string UnexpectedError {
+            get {
+                return ResourceManager.GetString("UnexpectedError", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Unpin.
         /// </summary>
         public static string Unpin {

--- a/src/PopForums/Resources/Resources.resx
+++ b/src/PopForums/Resources/Resources.resx
@@ -1246,4 +1246,7 @@
   <data name="AppRestartRequired" xml:space="preserve">
     <value>App restart is required</value>
   </data>
+  <data name="UnexpectedError" xml:space="preserve">
+    <value>Unexpected Error</value>
+  </data>
 </root>


### PR DESCRIPTION
Currently if an exception occurs or another type of error like 403/404 the error pages are not hooked up. Therefore the nice error handling is not working.

I have added an error handler controller which will pick up any errors caused when the app is running in a production state and navigate the user to a nice error page. The error pages that are now available are "Page Not Found", "Forbidden" & "Unexpected Error".

I have tested all three locally, and introduced a test method for triggering an unexpected error simple by navigating to `/Error/Throw`