### PR TITLE
Add EditorConfig For Codestyle Consistancy

### DIFF
--- a/src/.editorconfig
+++ b/src/.editorconfig
@@ -1,0 +1,31 @@
+# EditorConfig is awesome:http://EditorConfig.org
+
+# top-most EditorConfig file
+root = true
+
+# Don't use tabs for indentation.
+[ "*" ]
+indent_style = tab
+end_of_line = lf
+insert_final_newline = true
+# (Please don't specify an indent_size here; that has too many unintended consequences.)
+
+# Code files
+[*.{cs,csx,vb,vbx,cshtml}]
+indent_style = tab
+indent_size = 4
+
+# Xml project files
+[*.{csproj,vbproj,vcxproj,vcxproj.filters,proj,projitems,shproj}]
+indent_style = tab
+indent_size = 2
+
+# Xml config files
+[*.{props,targets,ruleset,config,nuspec,resx,vsixmanifest,vsct}]
+indent_style = tab
+indent_size = 2
+
+# JSON files
+[*.json]
+indent_style = space
+indent_size = 2


### PR DESCRIPTION
The origional developer of the project seems to use tabs as their preference, my own is spaces but that's a discussion for another time ;) Having said that to keep the codestyle consistant I believe we should adhere to the OG developers style.

I have added an editorconfig file that is set to adhere with the current PopForums codestyle therefore I will never introduce spacing to a tabbed file again :)