### PR TITLE
Automatically Subscribe to Topic when Posting

### DIFF
--- a/src/PopForums.Mvc/Areas/Forums/Controllers/ForumController.cs
+++ b/src/PopForums.Mvc/Areas/Forums/Controllers/ForumController.cs
@@ -116,6 +116,7 @@ namespace PopForums.Mvc.Areas.Forums.Controllers
 			Func<Topic, string> topicLinkGenerator = t => urlHelper.Action("Topic", "Forum", new { id = t.UrlName });
 			var topic = _forumService.PostNewTopic(forum, user, permissionContext, newPost, HttpContext.Connection.RemoteIpAddress.ToString(), userProfileUrl, topicLinkGenerator);
 			_topicViewCountService.SetViewedTopic(topic, HttpContext);
+			_subService.AddSubscribedTopic(user, topic);
 			return Json(new BasicJsonMessage { Result = true, Redirect = urlHelper.RouteUrl(new { controller = "Forum", action = "Topic", id = topic.UrlName }) });
 		}
 
@@ -339,6 +340,7 @@ namespace PopForums.Mvc.Areas.Forums.Controllers
 			Func<Post, string> postLinkGenerator = p => helper.Action("PostLink", "Forum", new { id = p.PostID });
 			var post = _topicService.PostReply(topic, user, newPost.ParentPostID, HttpContext.Connection.RemoteIpAddress.ToString(), false, newPost, DateTime.UtcNow, topicLink, unsubscribeLinkGenerator, userProfileUrl, postLinkGenerator);
 			_topicViewCountService.SetViewedTopic(topic, HttpContext);
+			_subService.AddSubscribedTopic(user, topic);
 			if (newPost.CloseOnReply && user.IsInRole(PermanentRoles.Moderator))
 				_topicService.CloseTopic(topic, user);
 			var urlHelper = Url;

--- a/src/PopForums.Test/Services/SubscribedTopicsServiceTests.cs
+++ b/src/PopForums.Test/Services/SubscribedTopicsServiceTests.cs
@@ -36,6 +36,19 @@ namespace PopForums.Test.Services
 		}
 
 		[Fact]
+		public void OnlySubscribeIfNotAlready()
+		{
+			var service = GetService();
+			var user = new User(123, DateTime.MaxValue);
+			var topic = new Topic(456);
+
+			_mockSubRepo.Setup(s => s.IsTopicSubscribed(user.UserID, topic.TopicID)).Returns(true);
+
+			service.AddSubscribedTopic(user, topic);
+			_mockSubRepo.Verify(s => s.AddSubscribedTopic(user.UserID, topic.TopicID), Times.Never());
+		}
+
+		[Fact]
 		public void RemoveSubTopic()
 		{
 			var service = GetService();

--- a/src/PopForums/Services/SubscribedTopicsService.cs
+++ b/src/PopForums/Services/SubscribedTopicsService.cs
@@ -34,7 +34,10 @@ namespace PopForums.Services
 
 		public void AddSubscribedTopic(User user, Topic topic)
 		{
-			_subscribedTopicsRepository.AddSubscribedTopic(user.UserID, topic.TopicID);
+			if (!IsTopicSubscribed(user, topic))
+			{
+				_subscribedTopicsRepository.AddSubscribedTopic(user.UserID, topic.TopicID);
+			}
 		}
 
 		public void RemoveSubscribedTopic(User user, Topic topic)


### PR DESCRIPTION
In #79, it is suggested that we subscribe to a topic when a user contributes i.e posts/authors the topic. I have subscribed the user to the topic whenever they post on it, also if they are already subscribed don't subscribe a second time which would cause multiple emails.

Added new unit test to verify that a user can only be subscribed to a topic once.
All test run and pass locally.