### PR TITLE
Make the Topic Title Editable for the Author

### DIFF
--- a/src/PopForums.Web/Areas/Forums/Views/Forum/Edit.cshtml
+++ b/src/PopForums.Web/Areas/Forums/Views/Forum/Edit.cshtml
@@ -27,7 +27,17 @@
 
 <form method="post">
 	<div class="postForm" role="form">
-		<input asp-for="Title" type="hidden"/>
+		@if (Model.IsTitleEditable)
+		{
+			<div class="form-group">
+				<input asp-for="Title" class="form-control" placeholder="@PopForums.Resources.Title" />
+			</div>
+		}
+		else
+		{
+			<input asp-for="Title" type="hidden" />
+		}
+
 		<textarea asp-for="FullText" class="form-control"></textarea>
 		<div class="checkbox">
 			<label for="IncludeSignature">

--- a/src/PopForums/Extensions/Users.cs
+++ b/src/PopForums/Extensions/Users.cs
@@ -10,5 +10,15 @@ namespace PopForums.Extensions
 				return false;
 			return user.IsInRole(PermanentRoles.Moderator) || user.UserID == post.UserID;
 		}
+
+		public static bool IsTopicTitleEditable(this User user, Topic topic)
+		{
+			if (user == null)
+			{
+				return false;
+			}
+
+			return user.IsInRole(PermanentRoles.Moderator) || topic.StartedByUserID == user.UserID;
+		}
 	}
 }

--- a/src/PopForums/Models/PostEdit.cs
+++ b/src/PopForums/Models/PostEdit.cs
@@ -16,5 +16,6 @@
 		public bool ShowSig { get; set; }
 		public string Comment { get; set; }
 		public bool IsPlainText { get; set; }
+		public bool IsTitleEditable { get; set; } = false;
 	}
 }


### PR DESCRIPTION
Unless you are a moderator once you create a topic you cannot rename it. This is a annoying, so allow the topic creator to edit their original post to update the title.

New tests added
All tests pass

Fixes #80 