### PR TITLE
Removed ability to resize objects in the TinyMCE rich text editor

### DIFF
--- a/src/PopForums.Web/wwwroot/lib/PopForums/PopForums.js
+++ b/src/PopForums.Web/wwwroot/lib/PopForums/PopForums.js
@@ -51,7 +51,8 @@ PopForums.editorSettings = {
 	link_title: false,
 	image_description: false,
 	image_dimensions: false,
-	browser_spellcheck : true
+	browser_spellcheck : true,
+	object_resizing: false
 };
 
 PopForums.checkScroll = function () {


### PR DESCRIPTION
Removed the ability to resize objects as documented by: https://www.tiny.cloud/docs/configure/advanced-editing-behavior/

The html parser removes width and height attributes from objects, so there is no need for users to have the ability to resize objects, as the changes are reverted on submission.