### PR TITLE
Persist Server Config On Initial Setup

### DIFF
--- a/src/PopForums/Services/SetupService.cs
+++ b/src/PopForums/Services/SetupService.cs
@@ -74,6 +74,8 @@ namespace PopForums.Services
 			settings.UseEsmtp = setupVariables.UseEsmtp;
 			settings.SmtpUser = setupVariables.SmtpUser;
 			settings.SmtpPassword = setupVariables.SmtpPassword;
+			settings.ServerDaylightSaving = setupVariables.ServerDaylightSaving;
+			settings.ServerTimeZone = setupVariables.ServerTimeZone;
 			_settingsManager.SaveCurrent();
 
 			var user = _userService.CreateUser(setupVariables.Name, setupVariables.Email, setupVariables.Password, true, "");


### PR DESCRIPTION
When setting up the forum initially there is server config and initial user config to be configured. DaylightSaving and ServerTimeZone config were not persisted to the database, so fell back to the defaults even though they may well have been changed. Updated to persist like the other config on the setup page.


![image](https://user-images.githubusercontent.com/30004860/50632165-dce69a00-0f3e-11e9-88d0-74f65296d147.png)
