### PR TITLE
Client Side Locale friendly Dates

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,10 +10,13 @@ bin
 obj
 packages
 
-src/PopForums.Web/wwwroot/lib
 /src/PopForums.Web/node_modules
 /package-lock.json
 src/PopForums.Web/package-lock.json
 /src/PopForums.Web/Areas/Forums
 *.pubxml
 node_modules
+
+/src/PopForums.Web/wwwroot/lib/*
+!/src/PopForums.Web/wwwroot/lib/PopForums/src/
+/src/PopForums.Web/wwwroot/lib/PopForums/src/Fonts

--- a/src/PopForums.Mvc/Areas/Forums/Extensions/ServiceCollections.cs
+++ b/src/PopForums.Mvc/Areas/Forums/Extensions/ServiceCollections.cs
@@ -45,14 +45,20 @@ namespace PopForums.Mvc.Areas.Forums.Extensions
 			services.AddTransient<IBroker, Broker>();
 			// this is required for error logging:
 			services.AddSingleton<IHttpContextAccessor, HttpContextAccessor>();
-			
+
 			var serviceProvider = services.BuildServiceProvider();
 			var setupService = serviceProvider.GetService<ISetupService>();
 			if (!setupService.IsConnectionPossible() || !setupService.IsDatabaseSetup())
 				return services;
 
 			services.AddAuthentication()
-				.AddCookie(PopForumsAuthorizationDefaults.AuthenticationScheme, option => option.ExpireTimeSpan = new TimeSpan(365, 0, 0, 0));
+				.AddCookie(PopForumsAuthorizationDefaults.AuthenticationScheme,
+					option =>
+						{
+							option.ExpireTimeSpan = new TimeSpan(365, 0, 0, 0);
+							option.LoginPath = "/Forums/Account/Login";//This should login page path
+							option.LogoutPath = "/Forums/Identity/Logout";//This should logout page path
+						});
 
 			return services;
 		}

--- a/src/PopForums.Mvc/Areas/Forums/TagHelpers/ForumReadIndicatorTagHelper.cs
+++ b/src/PopForums.Mvc/Areas/Forums/TagHelpers/ForumReadIndicatorTagHelper.cs
@@ -46,6 +46,7 @@ namespace PopForums.Mvc.Areas.Forums.TagHelpers
 				output.Attributes.Add("class", $"topicIndicator {Class}");
 			else
 				output.Attributes.Add("class", "topicIndicator");
+			output.TagMode = TagMode.StartTagAndEndTag;
 		}
     }
 }

--- a/src/PopForums.Mvc/Areas/Forums/Views/Account/Posts.cshtml
+++ b/src/PopForums.Mvc/Areas/Forums/Views/Account/Posts.cshtml
@@ -33,7 +33,7 @@
 			<td>
 				<h2>@Html.ActionLink(topic.Title, "Topic", "Forum", new { id = topic.UrlName, pageNumber = 1 }, null)</h2>
 				<small class="float-right d-none d-sm-block">
-					@PopForums.Resources.StartedBy: @topic.StartedByName @PopForums.Resources.In @Model.ForumTitles[topic.ForumID] | @PopForums.Resources.Views: @topic.ViewCount | @PopForums.Resources.Replies: @topic.ReplyCount | @PopForums.Resources.Last: <span class="lastPostTime fTime" data-utc="@topic.LastPostTime.ToString("o")">@TimeFormattingService.GetFormattedTime(topic.LastPostTime, profile)</span> @PopForums.Resources.By @topic.LastPostName
+					@PopForums.Resources.StartedBy: @topic.StartedByName @PopForums.Resources.In @Model.ForumTitles[topic.ForumID] | @PopForums.Resources.Views: @topic.ViewCount | @PopForums.Resources.Replies: @topic.ReplyCount | @PopForums.Resources.Last: <span class="lastPostTime fTime">@topic.LastPostTime.AsUtc8601()</span> @PopForums.Resources.By @topic.LastPostName
 				</small>
 			</td>
 		</tr>

--- a/src/PopForums.Mvc/Areas/Forums/Views/Account/ViewProfile.cshtml
+++ b/src/PopForums.Mvc/Areas/Forums/Views/Account/ViewProfile.cshtml
@@ -49,7 +49,7 @@
 
 				<div class="row">
 					<div class="col-4">@PopForums.Resources.Joined</div>
-					<div class="col-8">@TimeFormattingService.GetFormattedTime(Model.Joined, profile)</div>
+					<div class="col-8 unformatted-time">@Model.Joined.AsUtc8601()</div>
 				</div>
 
 				@if (Model.Dob.HasValue)
@@ -123,7 +123,7 @@
 						<div class="activityFeedPoints">+@item.Points</div>
 					}
 					<div>@Html.Raw(item.Message)</div>
-					<div class="text-right small">@TimeFormattingService.GetFormattedTime(item.TimeStamp, profile)</div>
+					<div class="text-right small unformatted-time">@item.TimeStamp.AsUtc8601()</div>
 				</div>
 			}
 		</div>
@@ -133,7 +133,7 @@
 			{
 				<div class="alert-light alert mt-2" title="@item.Description">
 					<h2>@item.Title</h2>
-					<div class="text-right small">@TimeFormattingService.GetFormattedTime(item.TimeStamp, profile)</div>
+					<div class="text-right small unformatted-time">@item.TimeStamp.AsUtc8601()</div>
 				</div>
 			}
 			@if (Model.UserAwards.Count == 0)

--- a/src/PopForums.Mvc/Areas/Forums/Views/Admin/App.cshtml
+++ b/src/PopForums.Mvc/Areas/Forums/Views/Admin/App.cshtml
@@ -9,12 +9,17 @@
 <head>
 	<meta name="viewport" content="width=device-width" />
 	<title>@PopForums.Resources.PopForumsAdmin</title>
-	<script src="~/lib/vue/dist/vue.js"></script>
+	<environment include="Development">
+		<script src="~/lib/vue/dist/vue.js"></script>
+	</environment>
+	<environment exclude="Development">
+		@*this is a different version of vue with performance enhancements + console warnings off*@
+		<script src="~/lib/vue/dist/vue.min.js"></script>
+	</environment>
 	<script src="~/lib/vue-router/dist/vue-router.min.js"></script>
-	<script src="~/lib/popper.js/dist/popper.min.js"></script>
 	<script src="~/lib/jquery/dist/jquery.min.js"></script>
 	<script src="~/lib/axios/dist/axios.min.js"></script>
-	<script src="~/lib/bootstrap/dist/js/bootstrap.min.js"></script>
+	<script src="~/lib/bootstrap/dist/js/bootstrap.bundle.min.js"></script>
 	<link href="~/lib/bootstrap/dist/css/bootstrap.min.css" rel="stylesheet" />
 	<style>
 		.fade-enter-active, .fade-leave-active {

--- a/src/PopForums.Mvc/Areas/Forums/Views/Favorites/Topics.cshtml
+++ b/src/PopForums.Mvc/Areas/Forums/Views/Favorites/Topics.cshtml
@@ -51,7 +51,7 @@ else
 				<td>
 					<h2><a asp-controller="@ForumController.Name" asp-action="Topic" asp-route-id="@topic.UrlName" asp-route-pageNumber="">@topic.Title</a></h2>
 					<small class="float-right d-none d-sm-block">
-						@PopForums.Resources.StartedBy: @topic.StartedByName @PopForums.Resources.In @Model.ForumTitles[topic.ForumID] | @PopForums.Resources.Views: @topic.ViewCount | @PopForums.Resources.Replies: @topic.ReplyCount | @PopForums.Resources.Last: <span class="lastPostTime fTime" data-utc="@topic.LastPostTime.ToString("o")">@TimeFormattingService.GetFormattedTime(topic.LastPostTime, profile)</span> @PopForums.Resources.By @topic.LastPostName
+						@PopForums.Resources.StartedBy: @topic.StartedByName @PopForums.Resources.In @Model.ForumTitles[topic.ForumID] | @PopForums.Resources.Views: @topic.ViewCount | @PopForums.Resources.Replies: @topic.ReplyCount | @PopForums.Resources.Last: <span class="lastPostTime fTime">@topic.LastPostTime.AsUtc8601()</span> @PopForums.Resources.By @topic.LastPostName
 					</small>
 				</td>
 			</tr>

--- a/src/PopForums.Mvc/Areas/Forums/Views/Feed/Index.cshtml
+++ b/src/PopForums.Mvc/Areas/Forums/Views/Feed/Index.cshtml
@@ -29,7 +29,7 @@
 {
 	<div class="alert alert-light mt-2">
 		<div class="feedItemText">@Html.Raw(item.Message)</div>
-		<div class="text-right small fTime" data-utc="@item.TimeStamp.ToString("o")">@TimeFormattingService.GetFormattedTime(item.TimeStamp, profile)</div>
+		<div class="text-right small fTime">@item.TimeStamp.AsUtc8601()</div>
 	</div>
 }
 	<div id="ActivityFeedTemplate" class="alert alert-light mt-2" style="display: none;">

--- a/src/PopForums.Mvc/Areas/Forums/Views/Forum/Index.cshtml
+++ b/src/PopForums.Mvc/Areas/Forums/Views/Forum/Index.cshtml
@@ -66,7 +66,7 @@ else
 			<td>
 				<h2><a asp-controller="@ForumController.Name" asp-action="Topic" asp-route-id="@topic.UrlName" asp-route-pageNumber="">@topic.Title</a></h2>
 				<small class="float-right d-none d-sm-block">
-					@PopForums.Resources.StartedBy: @topic.StartedByName | @PopForums.Resources.Views: @topic.ViewCount.ToString("N0") | @PopForums.Resources.Replies: @topic.ReplyCount.ToString("N0") | @PopForums.Resources.Last: <span class="lastPostTime fTime" data-utc="@topic.LastPostTime.ToString("o")">@TimeFormattingService.GetFormattedTime(topic.LastPostTime, profile)</span> @PopForums.Resources.By @topic.LastPostName
+					@PopForums.Resources.StartedBy: @topic.StartedByName | @PopForums.Resources.Views: @topic.ViewCount.ToString("N0") | @PopForums.Resources.Replies: @topic.ReplyCount.ToString("N0") | @PopForums.Resources.Last: <span class="lastPostTime fTime">@topic.LastPostTime.AsUtc8601()</span> @PopForums.Resources.By @topic.LastPostName
 				</small>
 			</td>
 		</tr>

--- a/src/PopForums.Mvc/Areas/Forums/Views/Forum/IndexQA.cshtml
+++ b/src/PopForums.Mvc/Areas/Forums/Views/Forum/IndexQA.cshtml
@@ -67,7 +67,7 @@ else
 			<td>
 				<h2><a asp-controller="@ForumController.Name" asp-action="Topic" asp-route-id="@topic.UrlName">@topic.Title</a></h2>
 				<small class="float-right d-none d-sm-block">
-					@PopForums.Resources.StartedBy: @topic.StartedByName | @PopForums.Resources.Views: @topic.ViewCount.ToString("N0") | @PopForums.Resources.Replies: @topic.ReplyCount.ToString("N0") | @PopForums.Resources.Last: <span class="lastPostTime fTime" data-utc="@topic.LastPostTime.ToString("o")">@TimeFormattingService.GetFormattedTime(topic.LastPostTime, profile)</span> @PopForums.Resources.By @topic.LastPostName
+					@PopForums.Resources.StartedBy: @topic.StartedByName | @PopForums.Resources.Views: @topic.ViewCount.ToString("N0") | @PopForums.Resources.Replies: @topic.ReplyCount.ToString("N0") | @PopForums.Resources.Last: <span class="lastPostTime fTime">@topic.LastPostTime.AsUtc8601()</span> @PopForums.Resources.By @topic.LastPostName
 				</small>
 			</td>
 		</tr>

--- a/src/PopForums.Mvc/Areas/Forums/Views/Forum/PostItem.cshtml
+++ b/src/PopForums.Mvc/Areas/Forums/Views/Forum/PostItem.cshtml
@@ -22,7 +22,7 @@
 			{
 				@:IP: @Model.Post.IP -
 			}
-			<span class="fTime" data-utc="@Model.Post.PostTime.ToString("o")">@TimeFormattingService.GetFormattedTime(Model.Post.PostTime, Model.Profile)</span>
+			<span class="fTime">@Model.Post.PostTime.AsUtc8601()</span>
 		</small>
 	</div>
 	@if (Model.Profile != null && !Model.Profile.HideVanity && (Model.Avatars).ContainsKey(Model.Post.UserID))
@@ -33,7 +33,7 @@
 	@Html.Raw(Model.Post.FullText)
 	@if (Model.Post.IsEdited && Model.Post.LastEditTime.HasValue)
 	{
-		<small>@String.Format(PopForums.Resources.NameLastEdit, Model.Post.LastEditName), <span class="fTime" data-utc="@Model.Post.LastEditTime.Value.ToString("o")">@TimeFormattingService.GetFormattedTime(Model.Post.LastEditTime.Value, Model.Profile)</span></small>
+		<small>@String.Format(PopForums.Resources.NameLastEdit, Model.Post.LastEditName), <span class="fTime">@Model.Post.LastEditTime.Value.AsUtc8601()</span></small>
 	}
 
 	@if (Model.Post.ShowSig && Model.Profile != null && !Model.Profile.HideVanity && (Model.Signatures).ContainsKey(Model.Post.UserID))

--- a/src/PopForums.Mvc/Areas/Forums/Views/Forum/QAPost.cshtml
+++ b/src/PopForums.Mvc/Areas/Forums/Views/Forum/QAPost.cshtml
@@ -52,7 +52,7 @@
 				{
 					@:IP: @Model.Post.IP -
 				}
-				<span class="fTime" data-utc="@Model.Post.PostTime.ToString("o")">@TimeFormattingService.GetFormattedTime(Model.Post.PostTime, profile)</span>
+				<span class="fTime">@Model.Post.PostTime.AsUtc8601()</span>
 			</small>
 		</div>
 		@if (!hideVanity && Model.Avatars.ContainsKey(Model.Post.UserID))
@@ -64,7 +64,7 @@
 	{<text>newPostBlock</text>}">@Html.Raw(Model.Post.FullText)</div>
 		@if (Model.Post.IsEdited && Model.Post.LastEditTime.HasValue)
 		{
-			<small>@String.Format(PopForums.Resources.NameLastEdit, Model.Post.LastEditName), <span class="fTime" data-utc="@Model.Post.LastEditTime.Value.ToString("o")">@TimeFormattingService.GetFormattedTime(Model.Post.LastEditTime.Value, profile)</span></small>
+			<small>@String.Format(PopForums.Resources.NameLastEdit, Model.Post.LastEditName), <span class="fTime">@Model.Post.LastEditTime.Value.AsUtc8601()</span></small>
 		}
 
 		@if (Model.Post.ShowSig && !hideVanity && (Model.Signatures).ContainsKey(Model.Post.UserID))
@@ -112,7 +112,7 @@
 	{<text>newPostBlock</text>}">
 					<hr />
 					<p class="text-muted">
-						@Html.ActionLink(comment.Name, "ViewProfile", AccountController.Name, new { id = comment.UserID }, null) - <span class="fTime" data-utc="@comment.PostTime.ToString("o")">@TimeFormattingService.GetFormattedTime(comment.PostTime, profile)</span>
+						@Html.ActionLink(comment.Name, "ViewProfile", AccountController.Name, new { id = comment.UserID }, null) - <span class="fTime">@comment.PostTime.AsUtc8601()</span>
 						@if (user != null && user.IsInRole(PermanentRoles.Moderator))
 						{<text> - IP: </text>@comment.IP}
 					</p>

--- a/src/PopForums.Mvc/Areas/Forums/Views/Forum/Recent.cshtml
+++ b/src/PopForums.Mvc/Areas/Forums/Views/Forum/Recent.cshtml
@@ -46,7 +46,7 @@
 			<td>
 				<h2>@Html.ActionLink(topic.Title, "Topic", "Forum", new { id = topic.UrlName, pageNumber = 1 }, null)</h2>
 				<small class="float-right d-none d-sm-block">
-					@PopForums.Resources.StartedBy: @topic.StartedByName @PopForums.Resources.In @Model.ForumTitles[topic.ForumID] | @PopForums.Resources.Views: @topic.ViewCount | @PopForums.Resources.Replies: @topic.ReplyCount | @PopForums.Resources.Last: <span class="lastPostTime fTime" data-utc="@topic.LastPostTime.ToString("o")">@TimeFormattingService.GetFormattedTime(topic.LastPostTime, profile)</span> @PopForums.Resources.By @topic.LastPostName
+					@PopForums.Resources.StartedBy: @topic.StartedByName @PopForums.Resources.In @Model.ForumTitles[topic.ForumID] | @PopForums.Resources.Views: @topic.ViewCount | @PopForums.Resources.Replies: @topic.ReplyCount | @PopForums.Resources.Last: <span class="lastPostTime fTime">@topic.LastPostTime.AsUtc8601()</span> @PopForums.Resources.By @topic.LastPostName
 				</small>
 			</td>
 		</tr>

--- a/src/PopForums.Mvc/Areas/Forums/Views/Home/Index.cshtml
+++ b/src/PopForums.Mvc/Areas/Forums/Views/Home/Index.cshtml
@@ -35,7 +35,7 @@
 					<h2><a asp-controller="Forum" asp-action="Index" asp-route-urlName="@forum.UrlName">@forum.Title</a></h2>
 					<p>@forum.Description</p>
 					<small class="float-right text-secondary d-none d-sm-block">
-						@PopForums.Resources.Topics: <span class="topicCount">@forum.TopicCount.ToString("N0")</span> | @PopForums.Resources.Posts: <span class="postCount">@forum.PostCount.ToString("N0")</span> | @PopForums.Resources.Last: <span class="lastPostTime fTime" data-utc="@forum.LastPostTime.ToString("o")">@TimeFormattingService.GetFormattedTime(forum.LastPostTime, profile)</span> @PopForums.Resources.By <span class="lastPostName">@forum.LastPostName</span>
+						@PopForums.Resources.Topics: <span class="topicCount">@forum.TopicCount.ToString("N0")</span> | @PopForums.Resources.Posts: <span class="postCount">@forum.PostCount.ToString("N0")</span> | @PopForums.Resources.Last: <span class="lastPostTime fTime">@forum.LastPostTime.AsUtc8601()</span> @PopForums.Resources.By <span class="lastPostName">@forum.LastPostName</span>
 					</small>
 				</td>
 			</tr>
@@ -53,7 +53,7 @@
 						<h2><a asp-controller="Forum" asp-action="Index" asp-route-urlName="@forum.UrlName">@forum.Title</a></h2>
 						<p>@forum.Description</p>
 						<small class="float-right text-secondary d-none d-sm-block">
-							@PopForums.Resources.Topics: <span class="topicCount">@forum.TopicCount.ToString("N0")</span> | @PopForums.Resources.Posts: <span class="postCount">@forum.PostCount.ToString("N0")</span> | @PopForums.Resources.Last: <span class="lastPostTime fTime" data-utc="@forum.LastPostTime.ToString("o")">@TimeFormattingService.GetFormattedTime(forum.LastPostTime, profile)</span> @PopForums.Resources.By <span class="lastPostName">@forum.LastPostName</span>
+							@PopForums.Resources.Topics: <span class="topicCount">@forum.TopicCount.ToString("N0")</span> | @PopForums.Resources.Posts: <span class="postCount">@forum.PostCount.ToString("N0")</span> | @PopForums.Resources.Last: <span class="lastPostTime fTime">@forum.LastPostTime.AsUtc8601()</span> @PopForums.Resources.By <span class="lastPostName">@forum.LastPostName</span>
 						</small>
 					</td>
 				</tr>

--- a/src/PopForums.Mvc/Areas/Forums/Views/PrivateMessages/Archive.cshtml
+++ b/src/PopForums.Mvc/Areas/Forums/Views/PrivateMessages/Archive.cshtml
@@ -37,7 +37,7 @@
 			</td>
 			<td><a asp-action="View" asp-route-id="@pm.PMID">@pm.Subject</a></td>
 			<td>@pm.UserNames</td>
-			<td><small class="fTime" data-utc="@pm.LastPostTime.ToString("o")">@TimeFormattingService.GetFormattedTime(pm.LastPostTime, profile)</small></td>
+			<td><small class="fTime">@pm.LastPostTime.AsUtc8601()</small></td>
 		</tr>
 	}
 </table>

--- a/src/PopForums.Mvc/Areas/Forums/Views/PrivateMessages/Index.cshtml
+++ b/src/PopForums.Mvc/Areas/Forums/Views/PrivateMessages/Index.cshtml
@@ -37,7 +37,7 @@
 			</td>
 			<td><a asp-action="View" asp-route-id="@pm.PMID">@pm.Subject</a></td>
 			<td>@pm.UserNames</td>
-			<td><small class="fTime" data-utc="@pm.LastPostTime.ToString("o")">@TimeFormattingService.GetFormattedTime(pm.LastPostTime, profile)</small></td>
+			<td><small class="fTime">@pm.LastPostTime.AsUtc8601()</small></td>
 		</tr>
 	}
 </table>

--- a/src/PopForums.Mvc/Areas/Forums/Views/PrivateMessages/View.cshtml
+++ b/src/PopForums.Mvc/Areas/Forums/Views/PrivateMessages/View.cshtml
@@ -25,7 +25,7 @@
 	<div class="postItem">
 		<div class="postUserData bg-primary text-light rounded mb-2 px-3 py-1">
 			<h3 class="postNameLink"><a asp-controller="Account" asp-action="ViewProfile" asp-route-id="@post.UserID" class="text-light">@post.Name</a></h3>
-			<small class="postTime text-right fTime" data-utc="@post.PostTime.ToString("o")">@TimeFormattingService.GetFormattedTime(post.PostTime, profile)</small>
+			<small class="postTime text-right fTime">@post.PostTime.AsUtc8601()</small>
 		</div>
 		@Html.Raw(post.FullText)
 	</div>

--- a/src/PopForums.Mvc/Areas/Forums/Views/Search/Index.cshtml
+++ b/src/PopForums.Mvc/Areas/Forums/Views/Search/Index.cshtml
@@ -67,7 +67,7 @@ else
 				<td>
 					<h2>@Html.ActionLink(topic.Title, "Topic", "Forum", new { id = topic.UrlName, pageNumber = 1 }, null)</h2>
 					<small class="float-right d-none d-sm-block">
-						@PopForums.Resources.StartedBy: @topic.StartedByName @PopForums.Resources.In @Model.ForumTitles[topic.ForumID] | @PopForums.Resources.Views: @topic.ViewCount | @PopForums.Resources.Replies: @topic.ReplyCount | @PopForums.Resources.Last: <span class="lastPostTime fTime" data-utc="@topic.LastPostTime.ToString("o")">@TimeFormattingService.GetFormattedTime(topic.LastPostTime, profile)</span> @PopForums.Resources.By @topic.LastPostName
+						@PopForums.Resources.StartedBy: @topic.StartedByName @PopForums.Resources.In @Model.ForumTitles[topic.ForumID] | @PopForums.Resources.Views: @topic.ViewCount | @PopForums.Resources.Replies: @topic.ReplyCount | @PopForums.Resources.Last: <span class="lastPostTime fTime">@topic.LastPostTime.AsUtc8601()</span> @PopForums.Resources.By @topic.LastPostName
 					</small>
 				</td>
 			</tr>

--- a/src/PopForums.Mvc/Areas/Forums/Views/Shared/PopForumsMaster.cshtml
+++ b/src/PopForums.Mvc/Areas/Forums/Views/Shared/PopForumsMaster.cshtml
@@ -6,13 +6,13 @@
     @RenderSection("HeaderContent", required: false)
 	<environment include="Development">
 		<script src="~/lib/signalr/dist/signalr.js"></script>
-		<script src="~/lib/PopForums/src/langTime.js"></script>
+		<script src="~/lib/PopForums/src/timesTranslated.js"></script>
+		<script src="~/lib/PopForums/src/BrowserDateTimeCulture.js"></script>
 		<script src="~/lib/PopForums/src/PopForums.js"></script>
 		<link href="~/lib/PopForums/src/PopForums.css" rel="stylesheet" />
 	</environment>
 	<environment exclude="Development">
 		<script src="~/lib/signalr/dist/signalr.min.js"></script>
-		<script src="~/lib/PopForums/dist/langTime.min.js"></script>
 		<script src="~/lib/PopForums/dist/PopForums.min.js"></script>
 		<link href="~/lib/PopForums/dist/PopForums.min.css" rel="stylesheet" />
 	</environment>

--- a/src/PopForums.Mvc/Areas/Forums/Views/Shared/PopForumsMaster.cshtml
+++ b/src/PopForums.Mvc/Areas/Forums/Views/Shared/PopForumsMaster.cshtml
@@ -4,16 +4,18 @@
 
 @section HeaderContent {
     @RenderSection("HeaderContent", required: false)
-    <environment include="Development">
-	    <script src="~/lib/signalr/dist/signalr.js"></script>
-	    <script src="~/lib/PopForums/src/PopForums.js"></script>
-	    <link href="~/lib/PopForums/src/PopForums.css" rel="stylesheet" />
-    </environment>
-    <environment exclude="Development">
-	    <script src="~/lib/signalr/dist/signalr.min.js"></script>
-	    <script src="~/lib/PopForums/dist/PopForums.min.js"></script>
-	    <link href="~/lib/PopForums/dist/PopForums.min.css" rel="stylesheet" />    
-    </environment>
+	<environment include="Development">
+		<script src="~/lib/signalr/dist/signalr.js"></script>
+		<script src="~/lib/PopForums/src/langTime.js"></script>
+		<script src="~/lib/PopForums/src/PopForums.js"></script>
+		<link href="~/lib/PopForums/src/PopForums.css" rel="stylesheet" />
+	</environment>
+	<environment exclude="Development">
+		<script src="~/lib/signalr/dist/signalr.min.js"></script>
+		<script src="~/lib/PopForums/dist/langTime.min.js"></script>
+		<script src="~/lib/PopForums/dist/PopForums.min.js"></script>
+		<link href="~/lib/PopForums/dist/PopForums.min.css" rel="stylesheet" />
+	</environment>
 }
 
 <div id="ForumContainer" class="container-fluid">

--- a/src/PopForums.Mvc/Areas/Forums/Views/Subscription/Topics.cshtml
+++ b/src/PopForums.Mvc/Areas/Forums/Views/Subscription/Topics.cshtml
@@ -51,7 +51,7 @@ else
 				<td>
 					<h2><a asp-controller="@ForumController.Name" asp-action="Topic" asp-route-id="@topic.UrlName" asp-route-pageNumber="">@topic.Title</a></h2>
 					<small class="float-right d-none d-sm-block">
-						@PopForums.Resources.StartedBy: @topic.StartedByName @PopForums.Resources.In @Model.ForumTitles[topic.ForumID] | @PopForums.Resources.Views: @topic.ViewCount | @PopForums.Resources.Replies: @topic.ReplyCount | @PopForums.Resources.Last: <span class="lastPostTime fTime" data-utc="@topic.LastPostTime.ToString("o")">@TimeFormattingService.GetFormattedTime(topic.LastPostTime, profile)</span> @PopForums.Resources.By @topic.LastPostName
+						@PopForums.Resources.StartedBy: @topic.StartedByName @PopForums.Resources.In @Model.ForumTitles[topic.ForumID] | @PopForums.Resources.Views: @topic.ViewCount | @PopForums.Resources.Replies: @topic.ReplyCount | @PopForums.Resources.Last: <span class="lastPostTime fTime">@topic.LastPostTime.AsUtc8601()</span> @PopForums.Resources.By @topic.LastPostName
 					</small>
 				</td>
 			</tr>

--- a/src/PopForums.Web/Views/Shared/_Layout.cshtml
+++ b/src/PopForums.Web/Views/Shared/_Layout.cshtml
@@ -1,12 +1,11 @@
 ﻿<!DOCTYPE html>
-<html>
+<html lang="@System.Threading.Thread.CurrentThread.CurrentUICulture.Name">
     <head>
         <meta charset="utf-8" />
         <meta name="viewport" content="width=device-width, initial-scale=1.0" />
         <title>@ViewBag.Title</title>
 		<script src="~/lib/jquery/dist/jquery.min.js"></script>
-	    <script src="~/lib/popper.js/dist/popper.min.js"></script>
-		<script src="~/lib/bootstrap/dist/js/bootstrap.min.js"></script>
+		<script src="~/lib/bootstrap/dist/js/bootstrap.bundle.min.js"></script>
 		<link href="~/lib/bootstrap/dist/css/bootstrap.min.css" rel="stylesheet" />
 		@RenderSection("HeaderContent", false)
     </head>

--- a/src/PopForums.Web/Views/_ViewImports.cshtml
+++ b/src/PopForums.Web/Views/_ViewImports.cshtml
@@ -1,2 +1,3 @@
 ﻿@using PopForums.Mvc
+@using PopForums.Extensions
 @addTagHelper "*, Microsoft.AspNetCore.Mvc.TagHelpers"

--- a/src/PopForums.Web/gulpfile.js
+++ b/src/PopForums.Web/gulpfile.js
@@ -1,4 +1,4 @@
-﻿/// <binding AfterBuild="default" />
+/// <binding AfterBuild="default" />
 const babel = require('gulp-babel');
 const bump = require('gulp-bump');
 const concat = require('gulp-concat');
@@ -56,10 +56,6 @@ gulp.task("bump", function () {
 		.pipe(gulp.dest("./wwwroot/lib/PopForums/"));
 });
 
-gulp.task("min", gulp.series(["resx2js","copies","js","css", "bump"]));
-
-gulp.task("default", gulp.series("min"));
-
 gulp.task("resx2js", function () {
 	//return string that should be written to file
 	function onwrite(result, file) {
@@ -92,3 +88,7 @@ gulp.task("resx2js", function () {
 		.pipe(injectStr.prepend('const timesTranslated = {};'))
 		.pipe(gulp.dest(targetPath + "/PopForums/src"));
 });
+
+gulp.task("min", gulp.series(["resx2js", "copies", "js", "css", "bump"]));
+
+gulp.task("default", gulp.series("min"));

--- a/src/PopForums.Web/gulpfile.js
+++ b/src/PopForums.Web/gulpfile.js
@@ -1,24 +1,25 @@
 ﻿/// <binding AfterBuild="default" />
+const babel = require('gulp-babel');
+const bump = require('gulp-bump');
+const concat = require('gulp-concat');
+const cssmin = require('gulp-cssmin');
+const gulp = require('gulp');
+const injectStr = require('gulp-inject-string');
+const merge = require('merge-stream');
+const path = require('path');
+const rename = require('gulp-rename');
+const resx_out = require('gulp-resx-out');
+const sourcemaps = require('gulp-sourcemaps');
+const uglify = require('gulp-uglify');
 
-var gulp = require("gulp"),
-	merge = require("merge-stream"),
-	babel = require("gulp-babel"),
-	cssmin = require("gulp-cssmin"),
-	uglify = require("gulp-uglify"),
-	sourcemaps = require("gulp-sourcemaps"),
-	rename = require("gulp-rename"),
-	bump = require("gulp-bump"),
-	resx_out = require("gulp-resx-out"),
-	path = require("path"),
-	concat = require('gulp-concat');
-
-var nodeRoot = "./node_modules/";
-var targetPath = "./wwwroot/lib/";
+const nodeRoot = "./node_modules/";
+const targetPath = "./wwwroot/lib/";
 
 gulp.task("copies", function () {
-	var streams = [
+	return merge([
 		gulp.src(nodeRoot + "bootstrap/dist/**/*").pipe(gulp.dest(targetPath + "/bootstrap/dist")),
-		gulp.src(nodeRoot + "popper.js/dist/umd/popper.min.js").pipe(gulp.dest(targetPath + "/popper.js/dist")),
+		// excluding popper as this is included in the .bundle.min bootstrap packages
+		// gulp.src(nodeRoot + "popper.js/dist/umd/popper.min.js").pipe(gulp.dest(targetPath + "/popper.js/dist")),
 		gulp.src(nodeRoot + "jquery/dist/**/*").pipe(gulp.dest(targetPath + "/jquery/dist")),
 		gulp.src(nodeRoot + "@microsoft/signalr/dist/browser/**/*").pipe(gulp.dest(targetPath + "/signalr/dist")),
 		gulp.src(nodeRoot + "tinymce/**/*").pipe(gulp.dest(targetPath + "/tinymce")),
@@ -26,18 +27,20 @@ gulp.task("copies", function () {
 		gulp.src(nodeRoot + "vue-router/dist/**/*").pipe(gulp.dest(targetPath + "/vue-router/dist")),
 		gulp.src(nodeRoot + "axios/dist/**/*").pipe(gulp.dest(targetPath + "/axios/dist")),
 		gulp.src(targetPath + "PopForums/src/Fonts/**/*").pipe(gulp.dest(targetPath + "/PopForums/dist/Fonts"))
-	];
-	return merge(streams);
+	]);
 });
 
 gulp.task("js", function() {
-	return gulp.src("./wwwroot/lib/PopForums/src/*.js")
-		.pipe(sourcemaps.init())
-		.pipe(babel({ presets: ["@babel/preset-env"], sourceMap: true }))
-		.pipe(uglify())
-		.pipe(rename({ suffix: '.min' }))
-		.pipe(sourcemaps.write("./"))
-		.pipe(gulp.dest(targetPath + "/PopForums/dist"));
+	return merge([["Admin.js"], ["timesTranslated.js", "BrowserDateTimeCulture.js", "PopForums.js"]]
+		.map((globs) => 
+			gulp.src(globs.map((g) => "./wwwroot/lib/PopForums/src/" + g))
+				.pipe(sourcemaps.init())
+				.pipe(babel({ presets: ["@babel/preset-env"], sourceMap: true }))
+				.pipe(concat(globs[globs.length - 1]))
+				.pipe(uglify())
+				.pipe(rename({ suffix: '.min' }))
+				.pipe(sourcemaps.write("./"))
+				.pipe(gulp.dest(targetPath + "/PopForums/dist"))));
 });
 
 gulp.task("css", function () {
@@ -53,25 +56,19 @@ gulp.task("bump", function () {
 		.pipe(gulp.dest("./wwwroot/lib/PopForums/"));
 });
 
-gulp.task("min", gulp.series(["copies","js","css", "bump"]));
+gulp.task("min", gulp.series(["resx2js","copies","js","css", "bump"]));
 
 gulp.task("default", gulp.series("min"));
 
 gulp.task("resx2js", function () {
 	//return string that should be written to file
-	let firstFile = true;
 	function onwrite(result, file) {
 		const fileName = path.parse(file.path).name;
 		const langMatch = /\.([\w-]+)$/.exec(fileName);
 		const lang = langMatch === null
 			? "en"
 			: langMatch[1];
-		let start = '';
-		if (firstFile) {
-			start = 'timeStrs = {};\r\n';
-			firstFile = false;
-		}
-		return start + `timeStrs["${lang}"] = ${JSON.stringify(result)};`;
+		return `timesTranslated["${lang}"] = ${JSON.stringify(result)};`;
 	}
 
 	const timeStrs = ["LessThanMinute", "MinutesAgo", "TodayTime", "YesterdayTime"];
@@ -91,6 +88,7 @@ gulp.task("resx2js", function () {
 			onwrite,
 			onparse
 		}))
-		.pipe(concat("langTime.js"))
+		.pipe(concat("timesTranslated.js"))
+		.pipe(injectStr.prepend('const timesTranslated = {};'))
 		.pipe(gulp.dest(targetPath + "/PopForums/src"));
 });

--- a/src/PopForums.Web/package.json
+++ b/src/PopForums.Web/package.json
@@ -20,9 +20,11 @@
     "gulp-babel": "8.0.0",
     "@babel/core": "7.8.4",
     "@babel/preset-env": "7.8.4",
+    "gulp-concat": "2.6.1",
     "gulp-sourcemaps": "2.6.5",
     "gulp-rename": "2.0.0",
-    "gulp-bump": "3.1.3" 
+    "gulp-resx-out": "1.0.1",
+    "gulp-bump": "3.1.3"
   },
   "babel": {
     "presets": [

--- a/src/PopForums.Web/package.json
+++ b/src/PopForums.Web/package.json
@@ -1,30 +1,33 @@
 {
   "name": "popforums",
   "version": "16.0.0",
+  "description": "Client side javascript to support the .Net based PopForums project",
+  "repository": "https://github.com/POPWorldMedia/POPForums",
+  "license": "MIT",
   "scripts": {},
   "dependencies": {
-    "@microsoft/signalr": "3.1.0",
-    "bootstrap": "4.3.1",
+    "@microsoft/signalr": "3.1.2",
+    "axios": "0.19.2",
+    "bootstrap": "4.4.1",
     "jquery": "3.4.1",
-    "popper.js": "1.15.0",
-    "tinymce": "5.1.6",
-    "vue": "2.6.10",
-    "vue-router": "3.1.3",
-    "axios": "0.19.0"
+    "tinymce": "5.2.0",
+    "vue": "2.6.11",
+    "vue-router": "3.1.6"
   },
   "devDependencies": {
+    "@babel/core": "7.8.7",
+    "@babel/preset-env": "7.8.7",
     "gulp": "4.0.2",
-    "merge-stream": "2.0.0",
-    "gulp-cssmin": "0.2.0",
-    "gulp-uglify": "3.0.2",
     "gulp-babel": "8.0.0",
-    "@babel/core": "7.8.4",
-    "@babel/preset-env": "7.8.4",
+    "gulp-bump": "3.1.3",
     "gulp-concat": "2.6.1",
-    "gulp-sourcemaps": "2.6.5",
+    "gulp-cssmin": "0.2.0",
+    "gulp-inject-string": "1.1.2",
     "gulp-rename": "2.0.0",
     "gulp-resx-out": "1.0.1",
-    "gulp-bump": "3.1.3"
+    "gulp-sourcemaps": "2.6.5",
+    "gulp-uglify": "3.0.2",
+    "merge-stream": "2.0.0"
   },
   "babel": {
     "presets": [

--- a/src/PopForums.Web/wwwroot/lib/PopForums/package.json
+++ b/src/PopForums.Web/wwwroot/lib/PopForums/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@popworldmedia/popforums",
-  "version": "17.0.0-prerelease.104",
+  "version": "17.0.0-prerelease.105",
   "description": "POP Forums client side",
   "scripts": {},
   "repository": {

--- a/src/PopForums.Web/wwwroot/lib/PopForums/package.json
+++ b/src/PopForums.Web/wwwroot/lib/PopForums/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@popworldmedia/popforums",
-  "version": "17.0.0-prerelease.105",
+  "version": "17.0.0-prerelease.108",
   "description": "POP Forums client side",
   "scripts": {},
   "repository": {

--- a/src/PopForums.Web/wwwroot/lib/PopForums/src/BrowserDateTimeCulture.js
+++ b/src/PopForums.Web/wwwroot/lib/PopForums/src/BrowserDateTimeCulture.js
@@ -1,0 +1,81 @@
+﻿// import { timesTranslated } from './times_translated';;
+
+class BrowserDateTimeCulture {
+	/* properties:
+	public:
+		getLocaleDateTime;
+	private:
+		_getLocaleTime;
+		_translate;
+	*/
+	constructor(pageLanguage, userLanguages) {
+		if (!userLanguages) {
+			userLanguages = [];
+		}
+		if (typeof userLanguages === 'string') {
+			userLanguages = [userLanguages];
+		}
+
+		const bestDateCulture = userLanguages.find((l) => l.startsWith(pageLanguage))
+			|| 'default'; //could use 'en' here?
+
+		// Intl.DateTimeFormat is OK back to IE11
+		this.getLocaleDateTime = (new Intl.DateTimeFormat(bestDateCulture, {
+				year: 'numeric',
+				month: 'numeric',
+				day: 'numeric',
+				hour: 'numeric',
+				minute: 'numeric',
+			})).format;
+		this._getLocaleTime = (new Intl.DateTimeFormat(bestDateCulture, {
+				hour: 'numeric',
+				minute: 'numeric',
+			})).format;
+		this._translate = timesTranslated[pageLanguage];
+	}
+
+	getLocaleFeedTime(dt) {
+		if (typeof dt === 'string') {
+			dt = new Date(dt); //note IE <= 8 do not parse iso dates, everthing else fine
+		}
+		if (!dt instanceof Date) {
+			// this will not work across iframes, but that should be irrelevant here
+			// potentially future iterations will be typescript?
+			throw new TypeError("dt argument of DateCultureHandler.getTime must be iso 8610 string or a Date");
+		}
+		if (isNaN(dt.getTime())) {
+			return {
+				disp: ''
+			};
+		}
+		const now = new Date();
+		const dateDiff = now.getDate() - dt.getDate();
+		if (dateDiff <= 1) {
+			const msPerMin = 60000;
+			const minsAgo = (now.getTime() - dt.getTime()) / msPerMin;
+			if (minsAgo < 1) {
+				return {
+					disp: this._translate.LessThanMinute,
+					recalc: Math.max(0, (1 - minsAgo) * msPerMin)
+				};
+			}
+			if (minsAgo < 60) {
+				return {
+					disp: this._translate.MinutesAgo.replace("{0}", minsAgo.toFixed()),
+					recalc: Math.max(0, (1 - minsAgo % 1) * msPerMin)
+				};
+			}
+			const formattedTime = this._getLocaleTime(dt);
+			const nextMidnight = new Date(now);
+			nextMidnight.setHours(0, 0, 0, 0);
+			nextMidnight.setDate(now.getDate() + 1);
+			return {
+				recalc: nextMidnight.getTime() - now.getTime(),
+				disp: dateDiff === 1
+					? this._translate.YesterdayTime.replace("{0}", formattedTime)
+					: this._translate.TodayTime.replace("{0}", formattedTime)
+			};
+		}
+		return { disp: this.getLocaleDateTime(dt) };
+	}
+}

--- a/src/PopForums.Web/wwwroot/lib/PopForums/src/BrowserDateTimeCulture.js
+++ b/src/PopForums.Web/wwwroot/lib/PopForums/src/BrowserDateTimeCulture.js
@@ -1,12 +1,21 @@
 ﻿// import { timesTranslated } from './times_translated';;
 
 class BrowserDateTimeCulture {
-	/* properties:
-	public:
-		getLocaleDateTime;
-	private:
-		_getLocaleTime;
-		_translate;
+	/* 
+	properties:
+		public:
+			-
+		private:
+			_localeTimeFormatter;
+			_localeDateFormatter
+			_translate;
+	methods:
+		public:
+			getLocaleDateTime
+			getLocaleFeedTime
+		private
+			_getDate
+
 	*/
 	constructor(pageLanguage, userLanguages) {
 		if (!userLanguages) {
@@ -20,34 +29,32 @@ class BrowserDateTimeCulture {
 			|| 'default'; //could use 'en' here?
 
 		// Intl.DateTimeFormat is OK back to IE11
-		this.getLocaleDateTime = (new Intl.DateTimeFormat(bestDateCulture, {
-				year: 'numeric',
-				month: 'numeric',
-				day: 'numeric',
-				hour: 'numeric',
-				minute: 'numeric',
-			})).format;
-		this._getLocaleTime = (new Intl.DateTimeFormat(bestDateCulture, {
-				hour: 'numeric',
-				minute: 'numeric',
-			})).format;
+		this._localeDateFormatter = (new Intl.DateTimeFormat(bestDateCulture, {
+			year: 'numeric',
+			month: 'numeric',
+			day: 'numeric',
+			hour: 'numeric',
+			minute: 'numeric',
+		})).format;
+		this._localeTimeFormatter = (new Intl.DateTimeFormat(bestDateCulture, {
+			hour: 'numeric',
+			minute: 'numeric',
+		})).format;
 		this._translate = timesTranslated[pageLanguage];
 	}
-
+	getLocaleDateTime(dt) {
+		dt = this._getDate(dt);
+		return dt
+			? this._localeDateFormatter(dt)
+			: '';
+	}
 	getLocaleFeedTime(dt) {
-		if (typeof dt === 'string') {
-			dt = new Date(dt); //note IE <= 8 do not parse iso dates, everthing else fine
-		}
-		if (!dt instanceof Date) {
-			// this will not work across iframes, but that should be irrelevant here
-			// potentially future iterations will be typescript?
-			throw new TypeError("dt argument of DateCultureHandler.getTime must be iso 8610 string or a Date");
-		}
-		if (isNaN(dt.getTime())) {
+		dt = this._getDate(dt);
+		if (!dt) {
 			return {
 				disp: ''
-			};
-		}
+			}
+		};
 		const now = new Date();
 		const dateDiff = now.getDate() - dt.getDate();
 		if (dateDiff <= 1) {
@@ -65,7 +72,7 @@ class BrowserDateTimeCulture {
 					recalc: Math.max(0, (1 - minsAgo % 1) * msPerMin)
 				};
 			}
-			const formattedTime = this._getLocaleTime(dt);
+			const formattedTime = this._localeTimeFormatter(dt);
 			const nextMidnight = new Date(now);
 			nextMidnight.setHours(0, 0, 0, 0);
 			nextMidnight.setDate(now.getDate() + 1);
@@ -76,6 +83,41 @@ class BrowserDateTimeCulture {
 					: this._translate.TodayTime.replace("{0}", formattedTime)
 			};
 		}
-		return { disp: this.getLocaleDateTime(dt) };
+		return { disp: this._localeDateFormatter(dt) };
+	}
+	_getDate(dt) {
+		if (typeof dt === 'string') {
+			dt = dt.trim();
+			if (dt === '') { return null }
+			dt = new Date(dt); //note IE <= 8 do not parse iso dates, everthing else fine
+		}
+		if (!dt instanceof Date || isNaN(dt.getTime())) {
+			// this will not work across iframes, but that should be irrelevant here
+			// potentially future iterations will be typescript?
+			throw new TypeError("dt argument of DateCultureHandler.getTime must be iso 8610 string or a Valid Date");
+		}
+		return dt;
 	}
 }
+/* note possible options are at https://devhints.io/wip/intl-datetime
+{
+  weekday: 'narrow' | 'short' | 'long',
+  era: 'narrow' | 'short' | 'long',
+  year: 'numeric' | '2-digit',
+  month: 'numeric' | '2-digit' | 'narrow' | 'short' | 'long',
+  day: 'numeric' | '2-digit',
+  hour: 'numeric' | '2-digit',
+  minute: 'numeric' | '2-digit',
+  second: 'numeric' | '2-digit',
+  timeZoneName: 'short' | 'long',
+
+  // Time zone to express it in
+  timeZone: 'Asia/Shanghai',
+  // Force 12-hour or 24-hour
+  hour12: true | false,
+
+  // Rarely-used options
+  hourCycle: 'h11' | 'h12' | 'h23' | 'h24',
+  formatMatcher: 'basic' | 'best fit'
+}
+*/

--- a/src/PopForums.Web/wwwroot/lib/PopForums/src/PopForums.js
+++ b/src/PopForums.Web/wwwroot/lib/PopForums/src/PopForums.js
@@ -783,7 +783,7 @@ PopForums.updateTimes = function () {
 			var dateUtcStr = el.innerText.trim();
 			var updateFn;
 			updateFn = function () {
-				if (el.parentElement) { // if no parent, element has been removed from the DOM
+				if ($(el).closest(document.body).length === 1) { // if no body ancestor, element has been removed from the DOM
 					var fTime = PopForums.dateTimeFormatter.getLocaleFeedTime(dateUtcStr);
 					el.innerText = fTime.disp;
 					if (typeof fTime.recalc === 'number') {

--- a/src/PopForums.Web/wwwroot/lib/PopForums/src/PopForums.js
+++ b/src/PopForums.Web/wwwroot/lib/PopForums/src/PopForums.js
@@ -85,7 +85,7 @@ PopForums.processLoginBase = function (path) {
 };
 
 PopForums.topicListSetup = function (forumID) {
-	PopForums.startTimerUpdater();
+	PopForums.startTimeUpdater();
 	var b = $("#NewTopicButton");
 	b.click(function () {
 		var n = $("#NewTopic");
@@ -222,7 +222,7 @@ PopForums.loadFeed = function () {
 		.then(function () {
 			return connection.invoke("listenToAll");
 		});
-	PopForums.startTimerUpdater();
+	PopForums.startTimeUpdater();
 };
 
 PopForums.populateFeedRow = function (data) {
@@ -241,7 +241,7 @@ PopForums.setReplyMorePosts = function (lastPostID) {
 };
 
 PopForums.topicSetup = function (topicID, pageIndex, pageCount, replyID) {
-	PopForums.startTimerUpdater();
+	PopForums.startTimeUpdater();
 	var lastPostID = $("#LastPostID").val();
 	PopForums.currentTopicState = new PopForums.TopicState(pageIndex, lastPostID, pageCount, topicID);
 
@@ -348,7 +348,7 @@ PopForums.topicSetup = function (topicID, pageIndex, pageCount, replyID) {
 };
 
 PopForums.qaTopicSetup = function (topicID) {
-	PopForums.startTimerUpdater();
+	PopForums.startTimeUpdater();
 	$(".postItem img:not('.avatar')").addClass("postImage");
 	$(document).on("click", ".commentLink", function () {
 		var replyID = $(this).parents(".postItem").attr("data-postid");
@@ -614,7 +614,7 @@ PopForums.homeSetup = function () {
 		.then(function () {
 			return connection.invoke("listenToAll");
 		});
-	PopForums.startTimerUpdater();
+	PopForums.startTimeUpdater();
 };
 
 PopForums.recentListen = function (pageSize) {
@@ -688,7 +688,7 @@ PopForums.updateForumStats = function (data) {
 	row.find(".newIndicator .icon-file-text2").removeClass("text-muted").addClass("text-warning");
 };
 
-PopForums.startTimerUpdater = function () {
+PopForums.startTimeUpdater = function () {
 	// change UTC to locale times (non updating)
 	$(".unformatted-time").each(function (_indx, el) {
 		if (!el.hasAttribute('data-localized')) {

--- a/src/PopForums.Web/wwwroot/lib/PopForums/src/timesTranslated.js
+++ b/src/PopForums.Web/wwwroot/lib/PopForums/src/timesTranslated.js
@@ -1,0 +1,7 @@
+const timesTranslated = {};
+timesTranslated["de"] = {"LessThanMinute":"Weniger als eine Minute zurück.","MinutesAgo":"Vor {0} Minuten","TodayTime":"Heute, {0}","YesterdayTime":"Gestern, {0}"};
+timesTranslated["es"] = {"LessThanMinute":"Hace menos de un minuto","MinutesAgo":"Hace {0} minutos","TodayTime":"Hoy, {0}","YesterdayTime":"Ayer, {0}"};
+timesTranslated["nl"] = {"LessThanMinute":"Minder dan een minuut geleden","MinutesAgo":"{0} minuten geleden","TodayTime":"Vandaag, {0}","YesterdayTime":"Gisteren, {0}"};
+timesTranslated["en"] = {"LessThanMinute":"Less than a minute ago","MinutesAgo":"{0} minutes ago","TodayTime":"Today, {0}","YesterdayTime":"Yesterday, {0}"};
+timesTranslated["uk"] = {"LessThanMinute":"Менше хвилини назад","MinutesAgo":"{0} хвилин назад","TodayTime":"Сьогодні, {0}","YesterdayTime":"Вчора, {0}"};
+timesTranslated["zh-TW"] = {"LessThanMinute":"不到一分鐘","MinutesAgo":"{0}分鐘前","TodayTime":"今天， {0}","YesterdayTime":"昨天， {0}"};

--- a/src/PopForums/Extensions/DateTimes.cs
+++ b/src/PopForums/Extensions/DateTimes.cs
@@ -1,0 +1,19 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace PopForums.Extensions
+{
+	public static class DateTimes
+	{
+		public static string AsUtc8601(this DateTime dt)
+		{
+			return dt.Kind switch
+			{
+				DateTimeKind.Utc => dt.ToString("o"),
+				DateTimeKind.Unspecified => dt.ToString("o") + 'Z',
+				_ => throw new ArgumentException("Date must NOT be DateTimeKind.local"),
+			};
+		}
+	}
+}

--- a/src/PopForums/Services/TimeFormattingService.cs
+++ b/src/PopForums/Services/TimeFormattingService.cs
@@ -4,11 +4,12 @@ using PopForums.Models;
 
 namespace PopForums.Services
 {
+	[Obsolete]
 	public interface ITimeFormattingService
 	{
 		string GetFormattedTime(DateTime utcDateTime, Profile profile);
 	}
-
+	[Obsolete]
 	public class TimeFormattingService : ITimeFormattingService
 	{
 		public TimeFormattingService(ISettingsManager settingsManager)


### PR DESCRIPTION
This takes all locale time handling from the server to the browser (#188):

1. all times/dates are initially sent to the browser as ISO 8601 strings - therefore if the browser happens to have JS disabled, it will make some sense to the person reading.
2. the gulpfile has been changed to make the relevant time strings from within the .resx files to a javascript object. I have **not** set this up as an automated task yet.
3. The formatting of the dates and times and the language used is taken from browser languages preferences. Even on the same forum I will see dd/mm/yyyy while you will see mm/dd/yyyy.
4. The calculation of UTC to local intervals is client side, and so it will make sense regardless of the timezone of the server and various forum users in different parts of the world. This also has the advantage of keeping ahead of a myriad of daylight savings rules which are ever changing.
5. all AJAX calls regarding date time strings are removed.
