### PR TITLE
Disable local account login and only allow external logins.

### DIFF
--- a/src/PopForums.Mvc/Areas/Forums/Authorization/PopForumsExternalLoginOnlyFilter.cs
+++ b/src/PopForums.Mvc/Areas/Forums/Authorization/PopForumsExternalLoginOnlyFilter.cs
@@ -1,0 +1,26 @@
+﻿using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.Mvc.Filters;
+using PopForums.Configuration;
+
+namespace PopForums.Mvc.Areas.Forums.Authorization
+{
+	public class PopForumsExternalLoginOnlyFilter : IActionFilter
+	{
+		private readonly IConfig _config;
+
+		public PopForumsExternalLoginOnlyFilter(IConfig config)
+		{
+			_config = config;
+		}
+
+		public void OnActionExecuting(ActionExecutingContext context)
+		{
+			if (_config.ExternalLoginOnly)
+				context.Result = new BadRequestResult();
+		}
+
+		public void OnActionExecuted(ActionExecutedContext context)
+		{
+		}
+	}
+}

--- a/src/PopForums.Mvc/Areas/Forums/Controllers/AccountController.cs
+++ b/src/PopForums.Mvc/Areas/Forums/Controllers/AccountController.cs
@@ -69,7 +69,8 @@ namespace PopForums.Mvc.Areas.Forums.Controllers
 		private readonly IReCaptchaService _reCaptchaService;
 
 		[PopForumsAuthorizationIgnore]
-		public ViewResult Create()
+		[TypeFilter(typeof(PopForumsExternalLoginOnlyFilter))]
+		public IActionResult Create()
 		{
 			SetupCreateData();
 			var signupData = new SignupData
@@ -95,8 +96,9 @@ namespace PopForums.Mvc.Areas.Forums.Controllers
 		}
 
 		[PopForumsAuthorizationIgnore]
+		[TypeFilter(typeof(PopForumsExternalLoginOnlyFilter))]
 		[HttpPost]
-		public async Task<ViewResult> Create(SignupData signupData)
+		public async Task<IActionResult> Create(SignupData signupData)
 		{
 			var ip = HttpContext.Connection.RemoteIpAddress.ToString();
 			if (_config.UseReCaptcha)
@@ -168,7 +170,8 @@ namespace PopForums.Mvc.Areas.Forums.Controllers
 		}
 
 		[PopForumsAuthorizationIgnore]
-		public async Task<ViewResult> Verify(string id)
+		[TypeFilter(typeof(PopForumsExternalLoginOnlyFilter))]
+		public async Task<IActionResult> Verify(string id)
 		{
 			var authKey = Guid.Empty;
 			if (!string.IsNullOrWhiteSpace(id) && !Guid.TryParse(id, out authKey))
@@ -184,14 +187,16 @@ namespace PopForums.Mvc.Areas.Forums.Controllers
 		}
 
 		[PopForumsAuthorizationIgnore]
+		[TypeFilter(typeof(PopForumsExternalLoginOnlyFilter))]
 		[HttpPost]
-		public RedirectToActionResult VerifyCode(string authorizationCode)
+		public IActionResult VerifyCode(string authorizationCode)
 		{
 			return RedirectToAction("Verify", new { id = authorizationCode });
 		}
 
 		[PopForumsAuthorizationIgnore]
-		public async Task<ViewResult> RequestCode(string email)
+		[TypeFilter(typeof(PopForumsExternalLoginOnlyFilter))]
+		public async Task<IActionResult> RequestCode(string email)
 		{
 			var user = await _userService.GetUserByEmail(email);
 			if (user == null)
@@ -209,14 +214,16 @@ namespace PopForums.Mvc.Areas.Forums.Controllers
 		}
 
 		[PopForumsAuthorizationIgnore]
-		public ViewResult Forgot()
+		[TypeFilter(typeof(PopForumsExternalLoginOnlyFilter))]
+		public IActionResult Forgot()
 		{
 			return View();
 		}
 
 		[PopForumsAuthorizationIgnore]
+		[TypeFilter(typeof(PopForumsExternalLoginOnlyFilter))]
 		[HttpPost]
-		public async Task<ViewResult> Forgot(string email)
+		public async Task<IActionResult> Forgot(string email)
 		{
 			var user = await _userService.GetUserByEmail(email);
 			if (user == null)
@@ -233,6 +240,7 @@ namespace PopForums.Mvc.Areas.Forums.Controllers
 		}
 
 		[PopForumsAuthorizationIgnore]
+		[TypeFilter(typeof(PopForumsExternalLoginOnlyFilter))]
 		public async Task<ActionResult> ResetPassword(string id)
 		{
 			var authKey = Guid.Empty;
@@ -248,6 +256,7 @@ namespace PopForums.Mvc.Areas.Forums.Controllers
 		}
 
 		[PopForumsAuthorizationIgnore]
+		[TypeFilter(typeof(PopForumsExternalLoginOnlyFilter))]
 		[HttpPost]
 		public async Task<ActionResult> ResetPassword(string id, PasswordResetContainer resetContainer)
 		{
@@ -269,6 +278,7 @@ namespace PopForums.Mvc.Areas.Forums.Controllers
 		}
 
 		[PopForumsAuthorizationIgnore]
+		[TypeFilter(typeof(PopForumsExternalLoginOnlyFilter))]
 		public ActionResult ResetPasswordSuccess()
 		{
 			var user = _userRetrievalShim.GetUser();
@@ -298,7 +308,8 @@ namespace PopForums.Mvc.Areas.Forums.Controllers
 			return View(userEdit);
 		}
 
-		public ViewResult Security()
+		[TypeFilter(typeof(PopForumsExternalLoginOnlyFilter))]
+		public IActionResult Security()
 		{
 			var user = _userRetrievalShim.GetUser();
 			if (user == null)
@@ -308,8 +319,9 @@ namespace PopForums.Mvc.Areas.Forums.Controllers
 			return View(userEdit);
 		}
 
+		[TypeFilter(typeof(PopForumsExternalLoginOnlyFilter))]
 		[HttpPost]
-		public async Task<ViewResult> ChangePassword(UserEditSecurity userEdit)
+		public async Task<IActionResult> ChangePassword(UserEditSecurity userEdit)
 		{
 			var user = _userRetrievalShim.GetUser();
 			if (user == null)
@@ -329,8 +341,9 @@ namespace PopForums.Mvc.Areas.Forums.Controllers
 			return View("Security", new UserEditSecurity { NewEmail = String.Empty, NewEmailRetype = String.Empty, IsNewUserApproved = _settingsManager.Current.IsNewUserApproved });
 		}
 
+		[TypeFilter(typeof(PopForumsExternalLoginOnlyFilter))]
 		[HttpPost]
-		public async Task<ViewResult> ChangeEmail(UserEditSecurity userEdit)
+		public async Task<IActionResult> ChangeEmail(UserEditSecurity userEdit)
 		{
 			var user = _userRetrievalShim.GetUser();
 			if (user == null)
@@ -511,7 +524,8 @@ namespace PopForums.Mvc.Areas.Forums.Controllers
 			return View();
 		}
 
-		public async Task<ViewResult> ExternalLogins()
+		[TypeFilter(typeof(PopForumsExternalLoginOnlyFilter))]
+		public async Task<IActionResult> ExternalLogins()
 		{
 			var user = _userRetrievalShim.GetUser();
 			if (user == null)
@@ -521,7 +535,8 @@ namespace PopForums.Mvc.Areas.Forums.Controllers
 			return View(externalAssociations);
 		}
 
-		public async Task<ActionResult> RemoveExternalLogin(int id)
+		[TypeFilter(typeof(PopForumsExternalLoginOnlyFilter))]
+		public async Task<IActionResult> RemoveExternalLogin(int id)
 		{
 			var user = _userRetrievalShim.GetUser();
 			if (user == null)

--- a/src/PopForums.Mvc/Areas/Forums/Services/AutoProvisionAccountService.cs
+++ b/src/PopForums.Mvc/Areas/Forums/Services/AutoProvisionAccountService.cs
@@ -1,0 +1,105 @@
+﻿using Microsoft.Extensions.Logging;
+using PopForums.Configuration;
+using PopForums.Extensions;
+using PopForums.ExternalLogin;
+using PopForums.Models;
+using PopForums.Services;
+using System;
+using System.Threading.Tasks;
+
+namespace PopForums.Mvc.Areas.Forums.Services
+{
+	public interface IAutoProvisionAccountService
+	{
+		Task<User> AutoProvisionAccountAsync(string username, string email, string ip);
+	}
+
+	public class AutoProvisionAccountService : IAutoProvisionAccountService
+	{
+		private readonly ISettingsManager _settingsManager;
+		private readonly IExternalUserAssociationManager _externalUserAssociationManager;
+		private readonly IUserService _userService;
+		private readonly IProfileService _profileService;
+		private readonly ISecurityLogService _securityLogService;
+		private readonly IUserRetrievalShim _userRetrievalShim;
+		private readonly IConfig _config;
+		private readonly ILogger<AutoProvisionAccountService> _log;
+
+		public AutoProvisionAccountService(ISettingsManager settingsManager, IExternalUserAssociationManager externalUserAssociationManager, IUserService userService, IProfileService profileService, ISecurityLogService securityLogService, IUserRetrievalShim userRetrievalShim, IConfig config, ILogger<AutoProvisionAccountService> log)
+		{
+			_settingsManager = settingsManager;
+			_externalUserAssociationManager = externalUserAssociationManager;
+			_userService = userService;
+			_profileService = profileService;
+			_securityLogService = securityLogService;
+			_userRetrievalShim = userRetrievalShim;
+			_config = config;
+			_log = log;
+		}
+
+		public async Task<User> AutoProvisionAccountAsync(string username, string email, string ip)
+		{
+			var user = await _userService.GetUserByEmail(email);
+
+			if (user == null)
+			{
+				username = await EnsureUniqueUsernameAsync(username);
+
+				user = await CreateUserAsync(username, email, ip);
+
+				_log.LogInformation($"Created new user for external email '{email}'.");
+			}
+			else
+			{
+				// Update the username to match the external login. If the username is already in use, generate a random one.
+				if (user.Name != username)
+				{
+					username = await EnsureUniqueUsernameAsync(username);
+
+					await _userService.ChangeName(user, username, user, ip);
+				}
+
+				_log.LogInformation($"Linking user to external email '{email}'.");
+			}
+
+			await CopyExternalUserPropertiesAsync(user, ip);
+
+			return user;
+		}
+
+		private async Task<User> CreateUserAsync(string username, string email, string ip)
+		{
+			var password = Guid.NewGuid().ToString().GetSHA256Hash();
+
+			var user = await _userService.CreateUser(username, email, password, true, ip);
+
+			var profile = new Profile
+			{
+				UserID = user.UserID,
+				TimeZone = _settingsManager.Current.ServerTimeZone,
+				IsDaylightSaving = true,
+				IsSubscribed = true,
+			};
+
+			await _profileService.Create(profile);
+
+			return user;
+		}
+
+		private async Task<string> EnsureUniqueUsernameAsync(string username)
+		{
+			if (await _userService.GetUserByName(username) != null)
+			{
+				_log.LogWarning($"Local username already exists for external username '{username}'.");
+
+				username += DateTime.Now.Ticks.ToString();
+			}
+
+			return username;
+		}
+
+		protected virtual async Task CopyExternalUserPropertiesAsync(User user, string ip)
+		{
+		}
+	}
+}

--- a/src/PopForums.Mvc/Areas/Forums/Views/Account/Login.cshtml
+++ b/src/PopForums.Mvc/Areas/Forums/Views/Account/Login.cshtml
@@ -1,10 +1,11 @@
 ﻿@inject IUserRetrievalShim UserRetrievalShim
 @inject ISettingsManager SettingsManager
+@inject IConfig Configuration
 @using PopForums.Configuration
 @model Dictionary<PopIdentity.ProviderType, string>
 @{
-    ViewBag.Title = PopForums.Resources.Login;
-    Layout = "~/Areas/Forums/Views/Shared/PopForumsMaster.cshtml";
+	ViewBag.Title = PopForums.Resources.Login;
+	Layout = "~/Areas/Forums/Views/Shared/PopForumsMaster.cshtml";
 	var user = UserRetrievalShim.GetUser();
 }
 
@@ -32,17 +33,20 @@
 
 @if (user == null)
 {
-	<div role="form">
-		<div class="form-group">
-			<label for="EmailLogin">@PopForums.Resources.Email</label>
-			<input type="text" name="EmailLogin" id="EmailLogin" class="form-control"/>
+	if (!Configuration.ExternalLoginOnly || Model.Count == 0)
+	{
+		<div role="form">
+			<div class="form-group">
+				<label for="EmailLogin">@PopForums.Resources.Email</label>
+				<input type="text" name="EmailLogin" id="EmailLogin" class="form-control" />
+			</div>
+			<div class="form-group">
+				<label for="PasswordLogin">@PopForums.Resources.Password</label>
+				<input type="password" name="PasswordLogin" id="PasswordLogin" class="form-control" />
+			</div>
+			<input id="LoginButton" type="button" value="@PopForums.Resources.Login" class="btn btn-primary" />
 		</div>
-		<div class="form-group">
-			<label for="PasswordLogin">@PopForums.Resources.Password</label>
-			<input type="password" name="PasswordLogin" id="PasswordLogin" class="form-control"/>
-		</div>
-		<input id="LoginButton" type="button" value="@PopForums.Resources.Login" class="btn btn-primary" />
-	</div>
+	}
 
 	if (Model.Count > 0)
 	{
@@ -58,9 +62,12 @@
 		</form>
 	}
 
-	<p>@PopForums.Resources.NotRegisteredQuestion <a asp-action="Create">@PopForums.Resources.CreateAnAccount</a>. <a asp-action="Forgot">@PopForums.Resources.ForgotPasswordQuestion</a></p>
+	if (!Configuration.ExternalLoginOnly)
+	{
+		<p>@PopForums.Resources.NotRegisteredQuestion <a asp-action="Create">@PopForums.Resources.CreateAnAccount</a>. <a asp-action="Forgot">@PopForums.Resources.ForgotPasswordQuestion</a></p>
+	}
 
-	<input type="hidden" id="Referrer" value="@((object)ViewBag.Referrer)"/>
+	<input type="hidden" id="Referrer" value="@((object)ViewBag.Referrer)" />
 }
 else
 {

--- a/src/PopForums.Mvc/Areas/Forums/Views/Shared/Components/UserNavigation/Default.cshtml
+++ b/src/PopForums.Mvc/Areas/Forums/Views/Shared/Components/UserNavigation/Default.cshtml
@@ -1,9 +1,13 @@
 ﻿@using PopForums.Configuration
 @model UserNavigationContainer
 @inject ISettingsManager SettingsManager
+@inject IConfig Configuration
 @if (Model.User == null)
 {
-	<li class="nav-item"><a asp-controller="@AccountController.Name" asp-action="Create" asp-route-area="Forums" class="nav-link">@PopForums.Resources.CreateAnAccount</a></li>
+	if (!Configuration.ExternalLoginOnly)
+	{
+		<li class="nav-item"><a asp-controller="@AccountController.Name" asp-action="Create" asp-route-area="Forums" class="nav-link">@PopForums.Resources.CreateAnAccount</a></li>
+	}
 	<li class="nav-item"><a asp-controller="@AccountController.Name" asp-action="Login" asp-route-area="Forums" class="nav-link">@PopForums.Resources.Login</a></li>
 	if (!SettingsManager.Current.IsPrivateForumInstance)
 	{
@@ -21,9 +25,16 @@ else
 			<a asp-controller="@FavoritesController.Name" asp-action="Topics" asp-route-pageNumber="" asp-route-area="Forums" class="dropdown-item">@PopForums.Resources.Favorites</a>
 			<div class="dropdown-divider"></div>
 			<a asp-controller="@AccountController.Name" asp-action="EditProfile" asp-route-area="Forums" class="dropdown-item">@PopForums.Resources.EditProfile</a>
-			<a asp-controller="@AccountController.Name" asp-action="Security" asp-route-area="Forums" class="dropdown-item">@PopForums.Resources.ChangeYourEmailPassword</a>
+			@if (!Configuration.ExternalLoginOnly)
+			{
+				<a asp-controller="@AccountController.Name" asp-action="Security" asp-route-area="Forums" class="dropdown-item">@PopForums.Resources.ChangeYourEmailPassword</a>
+			}
 			<a asp-controller="@AccountController.Name" asp-action="ManagePhotos" asp-route-area="Forums" class="dropdown-item">@PopForums.Resources.ManageYourPhotos</a>
-			<a asp-controller="@AccountController.Name" asp-action="ExternalLogins" asp-route-area="Forums" class="dropdown-item">@PopForums.Resources.ExternalLogins</a>
+
+			@if (!Configuration.ExternalLoginOnly)
+			{
+				<a asp-controller="@AccountController.Name" asp-action="ExternalLogins" asp-route-area="Forums" class="dropdown-item">@PopForums.Resources.ExternalLogins</a>
+			}
 			@if (Model.User.IsInRole(PermanentRoles.Admin))
 			{
 				<div class="dropdown-divider"></div>

--- a/src/PopForums.Web/PopForums.json
+++ b/src/PopForums.Web/PopForums.json
@@ -1,7 +1,7 @@
 ﻿{
   "PopForums": {
     "Database": {
-      "ConnectionString": "server=localhost;Database=popforums16;Trusted_Connection=True;"
+      "ConnectionString": "server=localhost;Database=popforums16;Trusted_Connection=True;",
     },
     "Cache": {
       "Seconds": 180,
@@ -20,6 +20,7 @@
       "UseReCaptcha": true,
       "SiteKey": "6Lc2drIUAAAAAPaa1iHozzu0Zt9rjCYHhjk4Jvtr",
       "SecretKey": "6Lc2drIUAAAAADXBXpTjMp67L-T5HdLe7OoKlLrG"
-    }
+    },
+    "ExternalLoginOnly": false
   }
 }

--- a/src/PopForums.Web/Startup.cs
+++ b/src/PopForums.Web/Startup.cs
@@ -12,6 +12,7 @@ using PopForums.Extensions;
 using PopForums.Mvc.Areas.Forums.Authorization;
 using PopForums.Mvc.Areas.Forums.Extensions;
 using PopForums.Sql;
+using PopForums.Mvc.Areas.Forums.Services;
 
 namespace PopForums.Web
 {
@@ -53,6 +54,9 @@ namespace PopForums.Web
 			services.AddPopForumsSql();
 			// this adds dependencies from the MVC project (and base dependencies) and sets up authentication for the forum
 			services.AddPopForumsMvc();
+
+			// Add the service to auto provision accounts from external logins when ExternalLoginOnly is enabled
+			services.AddTransient<IAutoProvisionAccountService, AutoProvisionAccountService>();
 
 			// use Redis cache for POP Forums using AzureKit
 			//services.AddPopForumsRedisCache();

--- a/src/PopForums/Configuration/Config.cs
+++ b/src/PopForums/Configuration/Config.cs
@@ -14,6 +14,7 @@
 		bool UseReCaptcha { get; }
 		string ReCaptchaSiteKey { get; }
 		string ReCaptchaSecretKey { get; }
+		bool ExternalLoginOnly { get; }
 	}
 
 	public class Config : IConfig
@@ -49,5 +50,6 @@
 		public bool UseReCaptcha => _configContainer.UseReCaptcha;
 		public string ReCaptchaSiteKey => _configContainer.ReCaptchaSiteKey;
 		public string ReCaptchaSecretKey => _configContainer.ReCaptchaSecretKey;
+		public bool ExternalLoginOnly => _configContainer.ExternalLoginOnly;
 	}
 }

--- a/src/PopForums/Configuration/ConfigContainer.cs
+++ b/src/PopForums/Configuration/ConfigContainer.cs
@@ -1,7 +1,7 @@
 ﻿namespace PopForums.Configuration
 {
-    public class ConfigContainer
-    {
+	public class ConfigContainer
+	{
 		public string DatabaseConnectionString { get; set; }
 		public int CacheSeconds { get; set; }
 		public string CacheConnectionString { get; set; }
@@ -14,5 +14,6 @@
 		public bool UseReCaptcha { get; set; }
 		public string ReCaptchaSiteKey { get; set; }
 		public string ReCaptchaSecretKey { get; set; }
+		public bool ExternalLoginOnly { get; set; }
 	}
 }

--- a/src/PopForums/Configuration/ConfigLoader.cs
+++ b/src/PopForums/Configuration/ConfigLoader.cs
@@ -29,7 +29,9 @@ namespace PopForums.Configuration
 			container.UseReCaptcha = useReCaptcha != null && bool.Parse(useReCaptcha);
 			container.ReCaptchaSiteKey = config["PopForums:ReCaptcha:SiteKey"];
 			container.ReCaptchaSecretKey = config["PopForums:ReCaptcha:SecretKey"];
+			var externalLoginOnly = config["PopForums:ExternalLoginOnly"];
+			container.ExternalLoginOnly = externalLoginOnly != null && bool.Parse(externalLoginOnly);
 			return container;
-		} 
+		}
 	}
 }


### PR DESCRIPTION
Possible solution for #183. All account actions have been decorated with an attribute to block if the configuration is set. All links on pages are disabled.

An auto provision account service is used to create new user accounts when logging in. It first tries to link an existing account with the same email. This is required since the setup creates the initial admin account and logging in is required to add external authentication options. The login page will only be visible if no external login options are set up.