### PR TITLE
Mutiple img tag Regex fix.

### DIFF
--- a/src/PopForums.Test/Services/TextParsingServiceClientHtmlToForumCodeTests.cs
+++ b/src/PopForums.Test/Services/TextParsingServiceClientHtmlToForumCodeTests.cs
@@ -263,5 +263,21 @@ namespace PopForums.Test.Services
 			var result = service.ClientHtmlToForumCode("<p>test</p>\r\n<p><img src=\"https://scontent.ftpa1-2.fna.fbcdn.net/v/t31.0-8/12119905_10153331542212955_4087525267669435874_o.jpg?_nc_cat=104&amp;_nc_ht=scontent.ftpa1-2.fna&amp;oh=bde1d73b39027f410a9506c19dfb4428&amp;oe=5D95ACD5\" alt=\"\" /></p><p>test</p>");
 			Assert.Equal("test\r\n\r\n[image=https://scontent.ftpa1-2.fna.fbcdn.net/v/t31.0-8/12119905_10153331542212955_4087525267669435874_o.jpg?_nc_cat=104&_nc_ht=scontent.ftpa1-2.fna&oh=bde1d73b39027f410a9506c19dfb4428&oe=5D95ACD5]\r\n\r\ntest", result);
 		}
+
+		[Fact]
+		public void ParseSequentialImages()
+		{
+			var service = GetService();
+			var result = service.ClientHtmlToForumCode("<p><img src=\"test1.jpg\" /><img src=\"test2.jpg\" /></p>");
+			Assert.Equal("[image=test1.jpg][image=test2.jpg]", result);
+		}
+
+		[Fact]
+		public void ParseNonSequentialImages()
+		{
+			var service = GetService();
+			var result = service.ClientHtmlToForumCode("<p><img src=\"test1.jpg\" /></p><p><img src=\"test2.jpg\" /></p>");
+			Assert.Equal("[image=test1.jpg]\r\n\r\n[image=test2.jpg]", result);
+		}
 	}
 }

--- a/src/PopForums/Services/TextParsingService.cs
+++ b/src/PopForums/Services/TextParsingService.cs
@@ -196,7 +196,7 @@ namespace PopForums.Services
 
 			// replace img and a tags
 			text = Regex.Replace(text, @"(<a href="")(\S+)""( *target=""?[_\w]*""?)*>", "[url=$2]", RegexOptions.IgnoreCase);
-			text = Regex.Replace(text, @"<img .*src=""(\S+)"".*/>", "[image=$1]", RegexOptions.IgnoreCase);
+			text = Regex.Replace(text, @"<img .*?src=""(\S+)"".*?/>", "[image=$1]", RegexOptions.IgnoreCase);
 			text = Regex.Replace(text, @"(<iframe )(\S+ )*(src=""https?://www.youtube.com/embed/)(\S+)("")( *\S+)*( */iframe>)", "[youtube=https://www.youtube.com/watch?v=$4]", RegexOptions.IgnoreCase);
 
 			// catch remaining HTML as invalid


### PR DESCRIPTION
**Issue**
I had a requirement to be able to put multiple img elements sequentially in a post. When submitted and run through the textparsingservice, the regex logic was only finding the last img tag, and replacing with the forum [image] code. The Regex was being too greedy.

**Fix**
The "greediness" of the Regex has been changed to allow it to match multiple img tags (.*? rather than .*). This SO post helped with determining what was happening: https://stackoverflow.com/questions/2301285/what-do-lazy-and-greedy-mean-in-the-context-of-regular-expressions.

**Testing**
Have tested locally with sequential and non-sequantial images and the issue seems resolved.