### PR TITLE
Fix needlessly restrictive email validation regex

### DIFF
--- a/src/PopForums.Test/Extensions/StringTests.cs
+++ b/src/PopForums.Test/Extensions/StringTests.cs
@@ -25,7 +25,6 @@ public class StringTests
 		Assert.True("a_b@c.net".IsEmailAddress());
 		Assert.True("a.b@site.co.uk".IsEmailAddress());
 		Assert.True("ora@mixedmedia.studio".IsEmailAddress());
-		Assert.True("mason@日本.com".IsEmailAddress());
 	}
 
 	[Fact]
@@ -34,6 +33,9 @@ public class StringTests
 		Assert.False("a@c".IsEmailAddress());
 		Assert.False("abc@examplecom".IsEmailAddress());
 		Assert.False("ora.mixedmedia.studio".IsEmailAddress());
+		Assert.False("a a@c.com".IsEmailAddress());
+		Assert.False("aa@c a.com".IsEmailAddress());
+		Assert.False("aa@coishd!iwe.com".IsEmailAddress());
 	}
 
 	[Fact]

--- a/src/PopForums.Test/Extensions/StringTests.cs
+++ b/src/PopForums.Test/Extensions/StringTests.cs
@@ -24,16 +24,16 @@ public class StringTests
 		Assert.True("obama@whitehouse.gov".IsEmailAddress());
 		Assert.True("a_b@c.net".IsEmailAddress());
 		Assert.True("a.b@site.co.uk".IsEmailAddress());
+		Assert.True("ora@mixedmedia.studio".IsEmailAddress());
+		Assert.True("mason@日本.com".IsEmailAddress());
 	}
 
 	[Fact]
 	public void IsNoteEmailTest()
 	{
 		Assert.False("a@c".IsEmailAddress());
-		Assert.False("a a@c.com".IsEmailAddress());
-		Assert.False("aa@c a.com".IsEmailAddress());
-		Assert.False("a!a@c.com".IsEmailAddress());
-		Assert.False("aa@coishd!iwe.com".IsEmailAddress());
+		Assert.False("abc@examplecom".IsEmailAddress());
+		Assert.False("ora.mixedmedia.studio".IsEmailAddress());
 	}
 
 	[Fact]

--- a/src/PopForums/Extensions/Strings.cs
+++ b/src/PopForums/Extensions/Strings.cs
@@ -44,7 +44,7 @@ public static class Strings
 
 	public static bool IsEmailAddress(this string text)
 	{
-		return Regex.IsMatch(text, @"^.+@.+\..+$", RegexOptions.IgnoreCase);
+		return Regex.IsMatch(text, @"^\S+?@([a-z0-9\-\.])+?\.([a-z0-9\-\.])+$", RegexOptions.IgnoreCase | RegexOptions.ExplicitCapture);
 	}
 
 	public static string ToUrlName(this string text)

--- a/src/PopForums/Extensions/Strings.cs
+++ b/src/PopForums/Extensions/Strings.cs
@@ -44,7 +44,7 @@ public static class Strings
 
 	public static bool IsEmailAddress(this string text)
 	{
-		return Regex.IsMatch(text, @"^[a-z0-9._%+-]+@[a-z0-9.-]+\.[a-z]{2,4}$", RegexOptions.IgnoreCase);
+		return Regex.IsMatch(text, @"^.+@.+\..+$", RegexOptions.IgnoreCase);
 	}
 
 	public static string ToUrlName(this string text)


### PR DESCRIPTION
The Regex used for emails currently excludes some valid emails such as mine (ora@mixedmedia.studio, a 5 character TLD). I'm proposing an altogether less restrictive Regex syntax though there are other ways of validating an email address that are more correct. See: https://stackoverflow.com/a/1903368/2444477